### PR TITLE
Fixed a semicolon in the client's source

### DIFF
--- a/makekyclient/Source.cpp
+++ b/makekyclient/Source.cpp
@@ -137,7 +137,7 @@ void help_function()
 	print_in_help_screen("'join group' ==> to join a group via entering its name if it exist");
 	print_in_help_screen("'join channel' ==> to join a channel via entering its name if it exist");
 	print_in_help_screen("'show messages ==> to show last messages of a group , channel or pv");
-	print_in_help_screen("'log out' ==> to log out from you account and program")
+	print_in_help_screen("'log out' ==> to log out from you account and program");
 	
 	system("pause");
 }


### PR DESCRIPTION
There was an issue with the Client's source file where the 140th missed a semicolon at the end.